### PR TITLE
fix(autoload): Add autoload to avoid void function wat-mode

### DIFF
--- a/wat-mode.el
+++ b/wat-mode.el
@@ -108,7 +108,7 @@
     map)
   "Keymap for `wat-mode', derived from `lisp-mode'.")
 
-
+;;;###autoload
 (define-derived-mode wat-mode lisp-mode "wat-mode"
   "Major mode for editing WebAssembly's text encoding."
   (use-local-map wat-mode-map)


### PR DESCRIPTION
If you attempt to open `.wat` or `.wast`, it will trigger `void function wat-mode ...`. This PR should avoid that.